### PR TITLE
Ensure obfuscate_env_vars doesn't fail with invalid vars.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -28,6 +28,8 @@ group :test do
   gem 'mocha',         '~> 0.11.0'
   gem 'rspec'
   gem 'simplecov',     '>= 0.4.0', :require => false
+  gem 'guard'
+  gem 'guard-rspec'
 end
 
 

--- a/Guardfile
+++ b/Guardfile
@@ -1,0 +1,24 @@
+# A sample Guardfile
+# More info at https://github.com/guard/guard#readme
+
+guard 'rspec', :version => 2 do
+  watch(%r{^spec/.+_spec\.rb$})
+  watch(%r{^lib/(.+)\.rb$})     { |m| "spec/lib/#{m[1]}_spec.rb" }
+  watch('spec/spec_helper.rb')  { "spec" }
+
+  # Rails example
+  watch(%r{^app/(.+)\.rb$})                           { |m| "spec/#{m[1]}_spec.rb" }
+  watch(%r{^app/(.*)(\.erb|\.haml)$})                 { |m| "spec/#{m[1]}#{m[2]}_spec.rb" }
+  watch(%r{^app/controllers/(.+)_(controller)\.rb$})  { |m| ["spec/routing/#{m[1]}_routing_spec.rb", "spec/#{m[2]}s/#{m[1]}_#{m[2]}_spec.rb", "spec/acceptance/#{m[1]}_spec.rb"] }
+  watch(%r{^spec/support/(.+)\.rb$})                  { "spec" }
+  watch('config/routes.rb')                           { "spec/routing" }
+  watch('app/controllers/application_controller.rb')  { "spec/controllers" }
+  
+  # Capybara request specs
+  watch(%r{^app/views/(.+)/.*\.(erb|haml)$})          { |m| "spec/requests/#{m[1]}_spec.rb" }
+  
+  # Turnip features and steps
+  watch(%r{^spec/acceptance/(.+)\.feature$})
+  watch(%r{^spec/acceptance/steps/(.+)_steps\.rb$})   { |m| Dir[File.join("**/#{m[1]}.feature")][0] || 'spec/acceptance' }
+end
+

--- a/lib/travis/support/helpers.rb
+++ b/lib/travis/support/helpers.rb
@@ -4,7 +4,7 @@ module Travis
 
     def obfuscate_env_vars(line)
       regex = /(?<=\=)(?:(?<q>['"]).*?[^\\]\k<q>|(.*?)(?= \w+=|$))/
-      line.gsub(regex) { |val| '[secure]' }
+      line.respond_to?(:gsub) ? line.gsub(regex) { |val| '[secure]' } : '[One of the secure variables in your .travis.yml has an invalid format.]'
     end
   end
 end

--- a/spec/travis/helpers_spec.rb
+++ b/spec/travis/helpers_spec.rb
@@ -37,5 +37,9 @@ describe Travis::Helpers do
       expected = 'FOO=[secure] BAR=[secure]'
       Travis::Helpers.obfuscate_env_vars('FOO="" BAR=d').should == expected
     end
+
+    it "doesn't fail on lines that are hashes" do
+      Travis::Helpers.obfuscate_env_vars("SOMEKEY=value" => nil).should == '[One of the secure variables in your .travis.yml has an invalid format.]'
+    end
   end
 end


### PR DESCRIPTION
When there's an invalid entry in the .travis.yml, the API fails to
return anything unfortunately as this method fails loudly when the
secure env variable is a hash entry rather than a string.

This change puts a slightly more helpful message in place.

Alternatively we could display the first couple of characters of the line in question?
