### PR TITLE
feature: improve Amqp (Bunny) wrapper

### DIFF
--- a/lib/patches/bunny_prefetch.rb
+++ b/lib/patches/bunny_prefetch.rb
@@ -1,0 +1,7 @@
+if defined?(Bunny)
+  class ::Bunny::Channel
+    def prefetch=(prefetch_count)
+      prefetch(prefetch_count)
+    end
+  end
+end

--- a/lib/travis/support/amqp.rb
+++ b/lib/travis/support/amqp.rb
@@ -40,8 +40,9 @@ Travis::Amqp::Publisher.class_eval do
       new(routing_key)
     end
 
-    def jobs(routing_key)
-      new("reporting.jobs.#{routing_key}", :type => 'topic', :name => 'reporting')
+    def jobs(routing_key, options = {})
+      options = { :type => 'topic', :name => 'reporting' }.update(options)
+      new("reporting.jobs.#{routing_key}", options)
     end
 
     def commands

--- a/lib/travis/support/amqp/bunny.rb
+++ b/lib/travis/support/amqp/bunny.rb
@@ -3,6 +3,9 @@ module Travis
     require 'travis/support/amqp/bunny/publisher'
     require 'travis/support/amqp/bunny/consumer'
 
+    require 'bunny'
+    require 'patches/bunny_prefetch'
+
     class << self
       def config
         @config
@@ -25,7 +28,6 @@ module Travis
 
       def connection
         @connection ||=  begin
-          require 'bunny'
           bunny = Bunny.new(config, :spec => '09')
           bunny.start
           bunny

--- a/lib/travis/support/amqp/bunny/consumer.rb
+++ b/lib/travis/support/amqp/bunny/consumer.rb
@@ -1,9 +1,94 @@
+require 'hashr'
+require 'travis/support/logging'
+
 module Travis
   module Amqp
     class Consumer
-      def initialize
-        raise 'AMQP Bunny consumer is not available or recommended for use, consider using march_hare'
+
+      class BunnyMetadataWrapper
+
+        class ProperiesWrapper < Hash
+          def getType
+            self[:type]
+          end
+        end
+
+        def initialize(channel, delivery_info, properties)
+          @channel = channel
+          @properties = properties
+          @delivery_info = delivery_info
+        end
+
+        def ack
+          @channel.ack(@delivery_info.delivery_tag)
+        end
+
+        def properties
+          ProperiesWrapper[@properties]
+        end
+
+        def redelivered?
+          @delivery_info.redelivered?
+        end
       end
+
+      class << self
+      end
+
+      include Logging
+
+      DEFAULTS = {
+        :subscribe => { :ack => false, :blocking => false },
+        :queue     => { :durable => true, :exclusive => false },
+        :channel   => { :prefetch => 1 },
+        :exchange  => { :name => nil, :routing_key => nil }
+      }
+
+      attr_reader :name, :options, :subscription
+
+      def initialize(name, options = {})
+        @name    = name
+        @options = Hashr.new(DEFAULTS.deep_merge(options))
+      end
+
+      def subscribe(options = {}, &block)
+        options = deep_merge(self.options.subscribe, options)
+        options[:block] = options.delete :blocking if options.has_key? :blocking
+        options[:manual_ack] = options.delete :ack if options.has_key? :ack
+        debug "subscribing to #{name.inspect} with #{options.inspect}"
+        @subscription = queue.subscribe(options) do |delivery_info, properties, payload|
+          metadata = BunnyMetadataWrapper.new(channel, delivery_info, properties)
+          block.call(metadata, payload)
+        end
+      end
+
+      def unsubscribe
+        debug "unsubscribing from #{name.inspect}"
+        subscription.cancel if subscription.try(:active?)
+      end
+
+      protected
+
+        def queue
+          @queue ||= channel.queue(name, options.queue).tap do |queue|
+            if options.exchange.name
+              routing_key = options.exchange.routing_key || name
+              queue.bind(options.exchange.name, :routing_key => routing_key)
+            end
+          end
+        end
+
+        def channel
+          @channel ||= Amqp.connection.create_channel.tap do |channel|
+            channel.prefetch(options[:channel][:prefetch] || DEFAULTS[:channel][:prefetch])
+          end
+        end
+
+        def deep_merge(hash, other)
+          hash.merge(other, &(merger = proc { |key, v1, v2| Hash === v1 && Hash === v2 ? v1.merge(v2, &merger) : v2 }))
+        end
+
+
     end
   end
 end

--- a/lib/travis/support/amqp/march_hare/consumer.rb
+++ b/lib/travis/support/amqp/march_hare/consumer.rb
@@ -34,6 +34,13 @@ module Travis
         subscription.cancel if subscription.try(:active?)
       end
 
+      def channel
+        @channel ||= Amqp.connection.create_channel.tap do |channel|
+          channel.prefetch = options[:channel][:prefetch] || DEFAULTS[:channel][:prefetch]
+        end
+      end
+
+
       protected
 
         def queue
@@ -42,12 +49,6 @@ module Travis
               routing_key = options.exchange.routing_key || name
               queue.bind(options.exchange.name, :routing_key => routing_key)
             end
-          end
-        end
-
-        def channel
-          Amqp.connection.create_channel.tap do |channel|
-            channel.prefetch = options[:channel][:prefetch] || DEFAULTS[:channel][:prefetch]
           end
         end
 

--- a/lib/travis/support/amqp/march_hare/publisher.rb
+++ b/lib/travis/support/amqp/march_hare/publisher.rb
@@ -16,20 +16,30 @@ module Travis
         @options = options.dup
         @name = @options.delete(:name) || ""
         @type = @options.delete(:type) || "direct"
+        @unique_channel = @options.delete(:unique_channel)
+        @dont_retry = @options.delete :dont_retry
       end
 
       def publish(data, options = {})
         data = MultiJson.encode(data)
         defaults = { :routing_key => routing_key, :properties => { :message_id => rand(100000000000).to_s } }
-        retrying do
+        if @dont_retry
           exchange.publish(data, deep_merge(defaults, options))
+        else
+          retrying do
+            exchange.publish(data, deep_merge(defaults, options))
+          end
         end
+      end
+
+      def channel
+        @channel ||= @unique_channel ? Amqp.connection.create_channel : self.class.channel
       end
 
       protected
 
         def exchange
-          @exchange ||= self.class.channel.exchange(name, :durable => true, :auto_delete => false, :type => type)
+          @exchange ||= channel.exchange(name, :durable => true, :auto_delete => false, :type => type)
         end
 
         def retrying(&block)


### PR DESCRIPTION
Supports Amqp::Consumer even in with bunny library. It enables travis-worker to run in jruby as well as MRI.

Pull request to travis-worker to work on MRI will be follow... (for now you can see it here https://github.com/final-ci/travis-worker/commit/a91811dfdd3601e6a66a20dfff8fa9d625f6b8e0)

Probably the same applies for travis-hub but not tested yet.
