### PR TITLE
Add `logs_readonly_database` ActiveRecord::Base configuration

### DIFF
--- a/lib/travis/support/database.rb
+++ b/lib/travis/support/database.rb
@@ -15,12 +15,14 @@ module Travis
 
         ActiveRecord::Base.configurations = {
           Travis.env => Travis.config.database.to_h,
-          'logs_database' => Travis.config.logs_database.to_h || Travis.config.database.to_h,
-          'logs_readonly_database' => Travis.config.logs_readonly_database.to_h || Travis.config.database.to_h
         }
         
         if Travis.config.logs_database
           ActiveRecord::Base.configurations['logs_database'] = Travis.config.logs_database.to_h
+        end
+
+        if Travis.config.logs_readonly_database
+          ActiveRecord::Base.configurations['logs_readonly_database'] = Travis.config.logs_readonly_database.to_h
         end
 
         ActiveRecord::Base.establish_connection(Travis.env)

--- a/lib/travis/support/database.rb
+++ b/lib/travis/support/database.rb
@@ -15,7 +15,8 @@ module Travis
 
         ActiveRecord::Base.configurations = {
           Travis.env => Travis.config.database,
-          'logs_database' => Travis.config.logs_database || Travis.config.database
+          'logs_database' => Travis.config.logs_database || Travis.config.database,
+          'logs_readonly_database' => Travis.config.logs_readonly_database || Travis.config.database
         }
 
         ActiveRecord::Base.establish_connection(Travis.env)


### PR DESCRIPTION
in support of transition from direct database access to API-based access of job logs.